### PR TITLE
Add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Development files
+.vscode
+
 # OS files
 .DS_Store
 thumbs.db


### PR DESCRIPTION
Removes .vscode config from the versioning cos we don't want to distribute that.