### PR TITLE
Make forum index configurable

### DIFF
--- a/appctl
+++ b/appctl
@@ -148,7 +148,7 @@ upgrade() {
     echo "Stopping containers for upgrade..."
     docker-compose stop
     create_new_backup
-    docker-compose build --pull --force-rm
+    docker-compose build --force-rm --pull
     docker-compose run --rm misago python manage.py migrate
     collectstatic
     echo "Upgrade has been completed, restarting containers..."
@@ -177,7 +177,7 @@ restart_containers() {
 # Rebuild misago container
 rebuild_misago_container() {
     require_setup
-    docker-compose build misago --force-rm
+    docker-compose build  --force-rm misago
     docker-compose stop misago
     docker-compose up --detach misago
 }
@@ -186,6 +186,12 @@ rebuild_misago_container() {
 show_stats() {
     require_setup
     docker stats
+}
+
+# Forum index configuration
+change_forumindex() {
+    require_setup
+    python3 wizard/forumindex.py
 }
 
 # E-mail configuration
@@ -299,6 +305,8 @@ if [[ $1 ]]; then
         rebuild_misago_container
     elif [[ $1 = "stats" ]]; then
         show_stats
+    elif [[ $1 = "forumindex" ]]; then
+        change_forumindex
     elif [[ $1 = "email" ]]; then
         change_email
     elif [[ $1 = "hostname" ]]; then

--- a/misago/misagodocker/settings.py
+++ b/misago/misagodocker/settings.py
@@ -544,3 +544,8 @@ MISAGO_PROFILE_FIELDS = [
         ],
     },
 ]
+
+
+# Display threads instead of categories on forum index?
+
+MISAGO_THREADS_ON_INDEX = os.environ.get('MISAGO_INDEX', "threads") == "threads"

--- a/wizard/forumindex.py
+++ b/wizard/forumindex.py
@@ -1,0 +1,43 @@
+from config import misago
+from utils import BOOL_TRUE, input_bool, input_choice, print_setup_changed_message
+
+
+def run_forum_index_wizard(env_file):
+    forum_index_prompt = [
+        "What content do you want to display on forum index?",
+        "",
+        "1 - Threads",
+        "2 - Categories",
+        "",
+        "Enter choice's number",
+    ]
+
+    forum_index = input_choice("\n".join(forum_index_prompt), "12", coerce_to=int)
+
+    choices_values = {1: "threads", 2: "categories"}
+
+    env_file["MISAGO_INDEX"] = choices_values[forum_index]
+
+
+def print_forum_index_setup(env_file):
+    if env_file.get("MISAGO_INDEX", "threads") == "threads":
+        print("Forum index is showing threads list.")
+    else:
+        print("Forum index is showing categories list.")
+
+
+def change_forum_index_setup(env_file):
+    print_forum_index_setup(misago)
+    print()
+    if input_bool("Change forum index?", default=False):
+        run_forum_index_wizard(env_file)
+        env_file.save()
+        print_setup_changed_message()
+
+
+if __name__ == "__main__":
+    if misago.is_file():
+        try:
+            change_forum_index_setup(misago)
+        except KeyboardInterrupt:
+            print()


### PR DESCRIPTION
This PR adds support for switching forum index between threads and categories via `./appctl forumindex`.

Fixes #35 